### PR TITLE
Subsume lockbox DSL

### DIFF
--- a/spec/protect/dsl_spec.rb
+++ b/spec/protect/dsl_spec.rb
@@ -1,18 +1,6 @@
 RSpec.describe Protect::Model::DSL do
   describe "class_methods" do
     context "secure_search" do
-      it "raises an error when there are no lockbox attributes specified" do
-        expect {
-          WithoutLockboxAttributes.secure_search :unencrypted_data
-        }.to raise_error(Protect::Error, "Attribute 'unencrypted_data' is not encrypted by Lockbox.")
-      end
-
-      it "raises an error when the source attribute is not encrypted by Lockbox" do
-        expect {
-          DslTesting.secure_search :unencrypted_data
-        }.to raise_error(Protect::Error,  "Attribute 'unencrypted_data' is not encrypted by Lockbox.")
-      end
-
       it "raises an error when a secure_search attribute is not of type :ore_64_8_v1" do
         expect {
           DslTesting.secure_search :email

--- a/spec/support/migrations/200_create_users_table_for_dsl_testing.rb
+++ b/spec/support/migrations/200_create_users_table_for_dsl_testing.rb
@@ -15,9 +15,6 @@ class CreateUsersTableForDslTesting < ActiveRecord::Migration[7.0]
 
       # Used to assert an error message is generated
       t.column :email_secure_search, :text
-
-      # Used to assert an error message is generated
-      t.text :unencrypted_data_ciphertext
     end
   end
 end

--- a/spec/support/models/crud_testing.rb
+++ b/spec/support/models/crud_testing.rb
@@ -1,17 +1,10 @@
 class CrudTesting < ActiveRecord::Base
   self.table_name = "users_for_crud_testing"
 
-  has_encrypted :email
-  has_encrypted :dob, type: :date
-  has_encrypted :last_login, type: :datetime
-  has_encrypted :age, type: :integer
-  has_encrypted :verified, type: :boolean
-  has_encrypted :latitude, type: :float
-
   secure_search :email
-  secure_search :dob
-  secure_search :last_login
-  secure_search :age
-  secure_search :verified
-  secure_search :latitude
+  secure_search :dob, type: :date
+  secure_search :last_login, type: :datetime
+  secure_search :age, type: :integer
+  secure_search :verified, type: :boolean
+  secure_search :latitude, type: :float
 end

--- a/spec/support/models/dsl_testing.rb
+++ b/spec/support/models/dsl_testing.rb
@@ -1,11 +1,5 @@
 class DslTesting < ActiveRecord::Base
   self.table_name = "users_for_dsl_testing"
 
-  has_encrypted :email
-  has_encrypted :full_name
-  has_encrypted :bio
-  has_encrypted :dob, type: :date
-  has_encrypted :updated_at, type: :date
-
-  secure_search :dob
+  secure_search :dob, type: :date
 end

--- a/spec/support/models/plaintext_testing.rb
+++ b/spec/support/models/plaintext_testing.rb
@@ -1,15 +1,8 @@
 class PlaintextTesting < ActiveRecord::Base
   self.table_name = "plaintext_users"
 
-
-  has_encrypted :dob, type: :date
-  has_encrypted :last_login, type: :datetime
-  has_encrypted :verified, type: :boolean
-  has_encrypted :latitude, type: :float
-
-
-  secure_search :dob
-  secure_search :last_login
-  secure_search :verified
-  secure_search :latitude
+  secure_search :dob, type: :date
+  secure_search :last_login, type: :datetime
+  secure_search :verified, type: :boolean
+  secure_search :latitude, type: :float
 end

--- a/spec/support/models/without_lockbox_attributes.rb
+++ b/spec/support/models/without_lockbox_attributes.rb
@@ -1,3 +1,0 @@
-class WithoutLockboxAttributes < ActiveRecord::Base
-  self.table_name = "users_for_dsl_testing"
-end


### PR DESCRIPTION
`secure_search` now accepts a `type` parameter (defaulting to :string) if not supplied.

`has_encrypted` is now called automatically by `secure_search`.

This means that all `has_encrypted` calls can be omitted from models.