### PR TITLE
Switch to protect_search_attrs accessor

### DIFF
--- a/lib/protect/model.rb
+++ b/lib/protect/model.rb
@@ -14,7 +14,7 @@ module Protect
       end
 
       def protect_search_attrs
-        @protect_search_attrs
+        @protect_search_attrs ||= {}
       end
     end
   end

--- a/lib/protect/model/dsl.rb
+++ b/lib/protect/model/dsl.rb
@@ -6,9 +6,7 @@ module Protect
       extend ActiveSupport::Concern
       class_methods do
         def secure_search(attribute, **options)
-          @protect_search_attrs ||= {}
-
-          if duplicate_secure_search_attribute?(@protect_search_attrs, attribute)
+          if duplicate_secure_search_attribute?(protect_search_attrs, attribute)
             raise Protect::Error, "Attribute '#{attribute}' is already specified as a secure search attribute."
           end
 
@@ -25,7 +23,7 @@ module Protect
             raise Protect::Error, "Column name '#{column_name}' is not of type :ore_64_8_v1 (in `secure_search :#{attribute}`)"
           end
 
-          @protect_search_attrs[attribute] = {
+          protect_search_attrs[attribute] = {
             searchable_attribute: column_name.to_s,
             type: type,
             lockbox_attribute: lockbox_attributes[attribute]

--- a/spec/protect/dsl_spec.rb
+++ b/spec/protect/dsl_spec.rb
@@ -1,21 +1,29 @@
 RSpec.describe Protect::Model::DSL do
   describe "class_methods" do
     context "secure_search" do
+      let(:model) {
+        Class.new(ActiveRecord::Base) do
+          self.table_name = DslTesting.table_name
+
+          secure_search :dob, type: :date
+        end
+      }
+
       it "raises an error when a secure_search attribute is not of type :ore_64_8_v1" do
         expect {
-          DslTesting.secure_search :email
+          model.secure_search :email
         }.to raise_error(Protect::Error,  "Column name 'email_secure_search' is not of type :ore_64_8_v1 (in `secure_search :email`)")
       end
 
       it "raises an error when secure_search has already been specified for an attribute" do
         expect {
-          DslTesting.secure_search :dob
+          model.secure_search :dob
         }.to raise_error(Protect::Error, "Attribute 'dob' is already specified as a secure search attribute.")
       end
 
       it "allows for secure_search to be specified on an attribute" do
         expect {
-          DslTesting.secure_search :full_name
+          model.secure_search :full_name
         }.to_not raise_error
       end
     end

--- a/spec/protect/model_spec.rb
+++ b/spec/protect/model_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe Protect::Model do
+  describe "class methods" do
+    context "with no protected attributes" do
+      let(:model) {
+        Class.new(ActiveRecord::Base) do
+          self.table_name = nil
+        end
+      }
+
+      it "detects that no attributes are being protected" do
+        expect(model.protect_search_attrs).to eql({})
+        expect(model.is_protected?).to be false
+      end
+    end
+
+    context "with some protected attributes" do
+      let(:model) { DslTesting }
+
+      it "detects that no attributes are being protected" do
+        expect(model.protect_search_attrs.keys).to eql([:dob])
+        expect(model.is_protected?).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
Switches over to using the `protect_search_attrs` accessor in the parts of the code that wasn't using it yet.

(Also fixes a use of `DslTesting.secure_search` that [was causing an error](https://cipherstash.slack.com/archives/C01G7UGNQ3U/p1667818823144279?thread_ts=1667812249.638309&cid=C01G7UGNQ3U) in the new tests.)