### PR TITLE
Fix: Kernel.silence_warnings provided by Rails

### DIFF
--- a/lib/protect.rb
+++ b/lib/protect.rb
@@ -23,27 +23,33 @@ module Protect
   end
 
   def self.encrypt(model)
-    # TODO: Raise an error if model is not protected
-    if model.is_protected?
-      bar = ProgressBar.new(model.count)
-
+    if respond_to?(:silence_warnings)
       # Silence warnings is added here to suppress Lockbox warning messages relating
       # to the presence of unencrypted plaintext fields.
       # When running this method we are aware that there are unencrypted fields.
       # Although this will silence all warnings, for now the improvement in UX
       # is favoured.
-      silence_warnings do
-          model.find_in_batches do |group|
-          group.each do |record|
-            record.attributes.each do |attr, val|
-              unless attr =~ /_ciphertext$/ || attr =~ /_secure_search$/
-                record.send("#{attr}=", val)
-              end
-            end
-            record.save!(validate: false)
-            bar.increment! 1
+      silence_warnings { encrypt_model(model) }
+    else
+      encrypt_model(model)
+    end
+  end
+
+  private
+
+  def self.encrypt_model(model)
+    raise Protect::Error, "Nothing to encrypt in #{model}" unless model.is_protected?
+
+    bar = ProgressBar.new(model.count)
+    model.find_in_batches do |group|
+      group.each do |record|
+        record.attributes.each do |attr, val|
+          unless attr =~ /_ciphertext$/ || attr =~ /_secure_search$/
+            record.send("#{attr}=", val)
           end
         end
+        record.save!(validate: false)
+        bar.increment! 1
       end
     end
   end


### PR DESCRIPTION
When not in Rails, there is no `silence_warnings` method available.

Also: raise an error when the model is not protected.