### PR TITLE
Fix select with block doesn't take arguments

### DIFF
--- a/lib/protect/model/query_methods.rb
+++ b/lib/protect/model/query_methods.rb
@@ -40,13 +40,9 @@ module Protect
       end
 
       def select(*fields)
-        search_attrs = protect_search_attrs
+        return super(*fields) unless is_protected?
 
-        if search_attrs.nil? || search_attrs.size == 0
-          return super(*fields)
-        end
-
-        modified_fields = protect_map_to_encrypted_attrs(search_attrs, fields)
+        modified_fields = protect_map_to_encrypted_attrs(protect_search_attrs, fields)
 
         super(*modified_fields)
       end


### PR DESCRIPTION
Fix for this failure.

<img width="723" alt="Screen Shot 2022-11-16 at 4 44 30 pm" src="https://user-images.githubusercontent.com/26052576/202093777-75267c87-e6a6-4979-8966-ae2b4e76f2dd.png">

The first thing I changed was to update the modified_args variable to be passed with a splat, i'm not fully understanding what's happening there, but that fixed the error message and the test passed. When inspecting the value in the failing test, fields was an empty array, and modified_args was coming back as an empty array. 

So I'm not following what the splat is doing to that empty array, if anyone is able to provide some guidance there that would appreciated.

The second thing I noticed was that it shouldn't have even been hitting the protect_map_to_encrypted_attrs method, as search_attrs was an empty object. The guard in place was only checking for nil, not size, so this PR updates that check as well.

Other thing to note is, that it's becoming clear that these overrides in the query methods are touching a whole bunch of stuff when running these tests, so starting to feel a little apprehensive about the approach, but will continue on and see if anything else is breaking.

