### PR TITLE
Fixes "undefined method 'protect_search_attrs'" for some PredicateBuilder#build calls.

### DIFF
--- a/lib/protect/model/predicate_builder.rb
+++ b/lib/protect/model/predicate_builder.rb
@@ -6,9 +6,12 @@ module Protect
       # Updates the attribute to the searchable attribute field (e.g email_secure_search)
       # and ORE encrypts the value.
       def build(attribute, value, *args)
-        search_attrs = table.send(:klass).protect_search_attrs
-        if search_attrs && !value.is_a?(ActiveRecord::StatementCache::Substitute)
-          search_attr = search_attrs[attribute.name.to_sym]&.fetch(:searchable_attribute)
+        klass = table.send(:klass)
+        if klass \
+          && klass.is_protected? \
+          && !value.is_a?(ActiveRecord::StatementCache::Substitute)
+        then
+          search_attr = klass.protect_search_attrs[attribute.name.to_sym]&.fetch(:searchable_attribute)
 
           if search_attr
             attribute = attribute.relation[search_attr]
@@ -20,6 +23,7 @@ module Protect
             end
           end
         end
+
         super(attribute, value, *args)
       end
 


### PR DESCRIPTION
This can sometimes occur for `ArelTable`s that are constructed to represent association/join records:

```
NoMethodError:
       undefined method `protect_search_attrs' for nil:NilClass
     # .../protect/lib/protect/model/predicate_builder.rb:9:in `build'
     # ./spec/models/promotion_spec.rb:66:in `block (4 levels) in <top (required)>'
```

They don't have an associated ActiveRecord subclass/model, so `table.send(:klass)` returns nil.