### PR TITLE
Fixes the assumption in Crud#protect_map_attributes

### DIFF
--- a/lib/protect/model/crud.rb
+++ b/lib/protect/model/crud.rb
@@ -19,12 +19,12 @@ module Protect
         end
 
         def protect_map_attributes(records)
-          return records unless records.is_a?(Array)
+          unless records.is_a?(Array) && self.respond_to?(:lockbox_attributes)
+            return records
+          end
 
           records.map do |attributes|
-            lockbox_attributes = self.lockbox_attributes
-
-            lockbox_attributes.map do | key, hash|
+            lockbox_attributes.map do |key, hash|
               virtual_attribute = hash[:attribute].to_sym
               if protect_search_attrs[virtual_attribute]
 

--- a/spec/protect/crud/create_spec.rb
+++ b/spec/protect/crud/create_spec.rb
@@ -122,6 +122,16 @@ RSpec.describe Protect::Model::CRUD do
         expect(user_two.first.email_secure_search).to_not be(nil)
         expect(user_two.first.email).to eq("pt.anderson@magnolia.com")
       end
+
+      it "works for regular tables" do
+        UnsecuredTesting.insert_all!([
+          { title: "Best", counter: 5, is_true: false },
+          { title: "Blurst", counter: nil, is_true: true },
+        ])
+
+        expect(UnsecuredTesting.where(title: "Best").first.counter).to be 5
+        expect(UnsecuredTesting.where(is_true: true).first.counter).to be nil
+      end
     end
   end
 end

--- a/spec/support/migrations/800_create_table_with_no_secured_attributes.rb
+++ b/spec/support/migrations/800_create_table_with_no_secured_attributes.rb
@@ -1,0 +1,9 @@
+class CreateTableWithNoSecuredAttributes < ActiveRecord::Migration[(ENV["RAILS_VERSION"] || "7.0").to_f]
+  def change
+    create_table :table_with_no_secured_attributes do |t|
+      t.text :title
+      t.integer :counter
+      t.boolean :is_true
+    end
+  end
+end

--- a/spec/support/models/unsecured_testing.rb
+++ b/spec/support/models/unsecured_testing.rb
@@ -1,0 +1,3 @@
+class UnsecuredTesting < ActiveRecord::Base
+  self.table_name = "table_with_no_secured_attributes"
+end


### PR DESCRIPTION
… about `lockbox_attributes` having been set up.

`protect_map_attributes()` was being called from `insert_all()`; the former makes the assumption that there's at least one lockbox/protect attribute defined, but this isn't always the case.

(I've added a regression test to demonstrate this. I admit to being slightly lazy in only adding it to the `insert_all!` path; I wanted to figure out a way to de-dupe the existing tests a bit, but it is very late.)