### PR TITLE
Check for null term before encrypting

### DIFF
--- a/lib/protect/active_record_extensions/ore_64_8_v1.rb
+++ b/lib/protect/active_record_extensions/ore_64_8_v1.rb
@@ -42,7 +42,11 @@ module Protect
       attr_reader :ciphertext
 
       def self.encrypt(term)
-        new(ore.encrypt(term))
+        if term.nil?
+          nil
+        else
+          new(ore.encrypt(term))
+        end
       end
 
       def initialize(ciphertext)


### PR DESCRIPTION
<img width="645" alt="Screen Shot 2022-11-17 at 10 34 58 am" src="https://user-images.githubusercontent.com/26052576/202317840-45828509-b767-4cb1-bd26-4ef3ee4a78c4.png">

Our ruby-ore-rs library is not currently set up to be able to encrypt a null value.

This PR adds in a guard to check if null before encrypting.