### PR TITLE
Has secure_search gracefully handle missing columns

### DIFF
--- a/lib/protect/model/dsl.rb
+++ b/lib/protect/model/dsl.rb
@@ -10,12 +10,24 @@ module Protect
             raise Protect::Error, "Attribute '#{attribute}' is already specified as a secure search attribute."
           end
 
+          column_name = "#{attribute}_secure_search"
           type = options.delete(:type) || :string
+
+          # Does the column exist?
+          if not columns_hash.has_key?(column_name)
+            # Quietly return only if we're pending DB migrations
+            # (eg. in the middle of a migration run, or setting up the Rails
+            #  app to start a DB migration run).
+            if ActiveRecord::Base.connection.migration_context.needs_migration?
+              logger.try(:debug, "Protect cannot find column '#{column_name}' on '#{self}' while pending DB migration")
+              return
+            else
+              raise Protect::Error, "Column name '#{column_name}' does not exist"
+            end
+          end
 
           # Call Lockbox to ensure that the underlying attribute is encrypted
           has_encrypted attribute, :type => type
-
-          column_name = "#{attribute}_secure_search"
 
           if !ore_64_8_v1?(column_name)
             raise Protect::Error, "Column name '#{column_name}' is not of type :ore_64_8_v1 (in `secure_search :#{attribute}`)"


### PR DESCRIPTION
… when waiting for DB migrations.

The case this is fixing:
- During `rake db:migrate` there is an error due to a missing `..._secure_search` column on a particular model. This model is being loaded when setting up the migrations run, eg. by Devise's `devise_for` routes helper method.
- We deploy new code (or run `git pull` on a dev’s laptop, or whatever).
- The new code has been updated with `secure_search <column>` in the model definition.
- We have DB migration(s) that create the `..._secure_search` column(s).
- When trying to `rake db:migrate` to run the DB migrations to add the column, User hits `Protect.secure_search(...)`, which looks for the `..._secure_search` column that does not exist.

This is what the error looks like:
```
NoMethodError: undefined method `sql_type_metadata' for nil:NilClass
/.../lib/protect/model/dsl.rb:36:in `ore_64_8_v1?'
/.../lib/protect/model/dsl.rb:22:in `secure_search'
/.../example-app/app/models/example.rb:125:in `<class:Example>'
/.../example-app/app/models/example.rb:50:in `<top (required)>'
...
/.../example-app/vendor/bundler/gems/devise-4.x.x/lib/devise/rails/routes.rb:242:in `devise_for'
```