### PR TITLE
Bloom Filter code

### DIFF
--- a/lib/protect/active_record_extensions/bloom_filter.rb
+++ b/lib/protect/active_record_extensions/bloom_filter.rb
@@ -2,16 +2,12 @@ require "openssl"
 
 module Protect
   module ActiveRecordExtensions
-    # A bloom filter implementation designed to be used with the *FilterMatch index classes.
-    #
-    # @private
+    # A bloom filter implementation designed to be used with *secure_text_search fields
     class BloomFilter
       K_MIN = 3
       K_MAX = 16
-      K_DEFAULT = 3
       M_MIN = 32
       M_MAX = 65536
-      M_DEFAULT = 256
 
       # The "set" bits of the bloom filter
       attr_reader :bits
@@ -56,15 +52,15 @@ module Protect
 
         @bits = Set.new()
 
-        @m = opts.fetch("filterSize", M_DEFAULT)
+        @m = opts.fetch("filterSize", nil)
 
         unless valid_m?(@m)
           raise Protect::Error, "filterSize must be a power of 2 between 32 and 65536 (got #{@m.inspect})"
         end
 
-        @k = opts.fetch("filterTermBits", K_DEFAULT)
+        @k = opts.fetch("filterTermBits", nil)
 
-        unless (K_MIN..K_MAX).to_a.include?(@k)
+        unless @k && (K_MIN..K_MAX).to_a.include?(@k)
           raise Protect::Error, "filterTermBits must be an integer between 3 and 16 (got #{@k.inspect})"
         end
       end

--- a/spec/protect/bloom_filter_spec.rb
+++ b/spec/protect/bloom_filter_spec.rb
@@ -11,19 +11,15 @@ RSpec.describe Protect::ActiveRecordExtensions::BloomFilter do
   let(:key) { "b6d6dba3be33ffaabb83af611ec043b9270dacdc7b3015ce2c36ba17cf2d3b2c" }
 
   describe ".new" do
-    it "returns a bloom filter with empty bits" do
-      filter = described_class.new(key)
-      expect(filter.bits).to eq(Set.new())
-    end
-
-    it "provides a default for m" do
-      filter = described_class.new(key)
-      expect(filter.m).to eq(256)
+    it "raises an error if filterSize not provided" do
+      expect {
+        described_class.new(key)
+      }.to raise_error(Protect::Error, "filterSize must be a power of 2 between 32 and 65536 (got nil)")
     end
 
     self::VALID_M_VALUES.each do |m|
       it "allows #{m} as a value for m" do
-        filter = described_class.new(key, {"filterSize" => m})
+        filter = described_class.new(key, {"filterSize" => m, "filterTermBits" => 3})
         expect(filter.m).to eq(m)
       end
     end
@@ -31,39 +27,40 @@ RSpec.describe Protect::ActiveRecordExtensions::BloomFilter do
     [0, 2, 16, 31, 513, 131072, "256", "ohai", nil, { foo: "bar" }, Object.new].each do |m|
       it "raises given invalid m of #{m.inspect}" do
         expect {
-          described_class.new(key, {"filterSize" => m})
+          described_class.new(key, {"filterSize" => m, "filterTermBits" => 3})
         }.to raise_error(Protect::Error, "filterSize must be a power of 2 between 32 and 65536 (got #{m.inspect})")
       end
     end
 
-    it "provides a default for k" do
-      filter = described_class.new(key)
-      expect(filter.k).to eq(3)
+    it "raises an error if filterTermBits not provided" do
+      expect {
+        described_class.new(key, {"filterSize" => 256})
+      }.to raise_error(Protect::Error, "filterTermBits must be an integer between 3 and 16 (got nil)")
     end
 
     self::VALID_K_VALUES.each do |k|
       it "allows #{k} as a value for k" do
-        filter = described_class.new(key, {"filterTermBits" => k})
+        filter = described_class.new(key, {"filterTermBits" => k, "filterSize" => 256})
         expect(filter.k).to eq(k)
       end
     end
 
     it "raises when k is < 3" do
       expect {
-        described_class.new(key, {"filterTermBits" => 2})
+        described_class.new(key, {"filterTermBits" => 2, "filterSize" => 256})
       }.to raise_error(Protect::Error, "filterTermBits must be an integer between 3 and 16 (got 2)")
     end
 
     it "raises when k is > 16" do
       expect {
-        described_class.new(key, {"filterTermBits" => 17})
+        described_class.new(key, {"filterTermBits" => 17, "filterSize" => 256})
       }.to raise_error(Protect::Error, "filterTermBits must be an integer between 3 and 16 (got 17)")
     end
 
     [3.5, "4", "ohai", nil, { foo: "bar" }, Object.new].each do |k|
       it "raises given invalid value of k #{k}" do
         expect {
-          described_class.new(key, {"filterTermBits" => k})
+          described_class.new(key, {"filterTermBits" => k, "filterSize" => 256})
         }.to raise_error(Protect::Error, "filterTermBits must be an integer between 3 and 16 (got #{k.inspect})")
       end
     end
@@ -72,7 +69,7 @@ RSpec.describe Protect::ActiveRecordExtensions::BloomFilter do
       key = SecureRandom.hex(16)
 
       expect {
-        described_class.new(key)
+        described_class.new(key, {"filterTermBits" => 16, "filterSize" => 256})
       }.to raise_error(Protect::Error, "expected bloom filter key to have length=32, got length=16")
     end
 
@@ -80,7 +77,7 @@ RSpec.describe Protect::ActiveRecordExtensions::BloomFilter do
       key = ""
 
       expect {
-        described_class.new(key)
+        described_class.new(key, {"filterTermBits" => 16, "filterSize" => 256})
       }.to raise_error(Protect::Error, "expected bloom filter key to have length=32, got length=0")
     end
 
@@ -88,14 +85,14 @@ RSpec.describe Protect::ActiveRecordExtensions::BloomFilter do
       key = "ZZZ"
 
       expect {
-        described_class.new(key)
+        described_class.new(key, {"filterTermBits" => 16, "filterSize" => 256})
       }.to raise_error(Protect::Error, 'expected bloom filter key to be a hex-encoded string (got "ZZZ")')
     end
 
     [3.5, 4, nil, { foo: "bar" }, Object.new].each do |key|
       it "raises given invalid key #{key.inspect}" do
         expect {
-          described_class.new(key)
+          described_class.new(key, {"filterTermBits" => 16, "filterSize" => 256})
         }.to raise_error(Protect::Error, "expected bloom filter key to be a hex-encoded string (got #{key.inspect})")
       end
     end
@@ -103,8 +100,8 @@ RSpec.describe Protect::ActiveRecordExtensions::BloomFilter do
 
   describe "#add" do
     it "accepts a single term or a list of terms" do
-      filter_a = described_class.new(key)
-      filter_b = described_class.new(key)
+      filter_a = described_class.new(key, {"filterTermBits" => 16, "filterSize" => 256})
+      filter_b = described_class.new(key, {"filterTermBits" => 16, "filterSize" => 256})
 
       filter_a.add("abc")
       filter_b.add(["abc"])
@@ -116,8 +113,8 @@ RSpec.describe Protect::ActiveRecordExtensions::BloomFilter do
     # In practice there will be 1 to k entries. Less than k entries will be in the set
     # in the case that any of the first k slices of the HMAC have the same value.
     it "adds k entries to bits for a single term when there are no hash collisions" do
-      filter = described_class.new(key)
-
+      filter = described_class.new(key, {"filterTermBits" => 3, "filterSize" => 256})
+      # binding.pry
       # A term that's known to not have collisions in the first k slices for the test key
       filter.add("yes")
 
@@ -126,7 +123,7 @@ RSpec.describe Protect::ActiveRecordExtensions::BloomFilter do
 
     self::VALID_K_VALUES.each do |k|
       it "adds at most #{k} entries to bits for a single term when k=#{k}" do
-        filter = described_class.new(key, {"filterTermBits" => k})
+        filter = described_class.new(key, {"filterTermBits" => k, "filterSize" => 256})
         random_term = SecureRandom.base64(3)
 
         filter.add(random_term)
@@ -139,7 +136,7 @@ RSpec.describe Protect::ActiveRecordExtensions::BloomFilter do
 
     self::VALID_M_VALUES.each do |m|
       it "adds bit positions with values >= 0 and < #{m} when m=#{m}" do
-        filter = described_class.new(key, {"filterSize" => m})
+        filter = described_class.new(key, {"filterSize" => m, "filterTermBits" => 3})
         random_term = SecureRandom.base64(3)
 
         filter.add(random_term)
@@ -152,7 +149,7 @@ RSpec.describe Protect::ActiveRecordExtensions::BloomFilter do
     end
 
     it "returns the bloom filter instance" do
-      filter = described_class.new(key)
+      filter = described_class.new(key, {"filterSize" => 256, "filterTermBits" => 3})
 
       result = filter.add("yes")
 
@@ -162,8 +159,8 @@ RSpec.describe Protect::ActiveRecordExtensions::BloomFilter do
 
   describe "#subset?" do
     it "returns true when the other filter is a subset" do
-      filter_a = described_class.new(key)
-      filter_b = described_class.new(key)
+      filter_a = described_class.new(key, {"filterSize" => 256, "filterTermBits" => 3})
+      filter_b = described_class.new(key, {"filterSize" => 256, "filterTermBits" => 3})
 
       filter_a.add("yes")
       filter_b.add("yes")
@@ -172,8 +169,8 @@ RSpec.describe Protect::ActiveRecordExtensions::BloomFilter do
     end
 
     it "returns false when the other filter is not a subset" do
-      filter_a = described_class.new(key)
-      filter_b = described_class.new(key)
+      filter_a = described_class.new(key, {"filterSize" => 256, "filterTermBits" => 3})
+      filter_b = described_class.new(key, {"filterSize" => 256, "filterTermBits" => 3})
 
       filter_a.add("yes")
       filter_b.add("ner")
@@ -210,16 +207,10 @@ RSpec.describe Protect::ActiveRecordExtensions::BloomFilter do
 
   describe "#to_a" do
     it "returns bits as an array" do
-      filter = described_class.new(key).add("a")
+      filter = described_class.new(key, {"filterSize" => 256, "filterTermBits" => 3}).add("a")
 
       expect(filter.to_a).to be_instance_of(Array)
       expect(Set.new(filter.to_a)).to eq(filter.bits)
-    end
-
-    it "works when bits is empty" do
-      filter = described_class.new(key)
-
-      expect(filter.to_a).to eq([])
     end
   end
 end


### PR DESCRIPTION
This is a copy paste from the code in the RubyClient including specs

https://github.com/cipherstash/ruby-client/blob/main/lib/cipherstash/index/bloom_filter.rb
https://github.com/cipherstash/ruby-client/blob/main/spec/cipherstash/index/bloom_filter_spec.rb

We are implementing Bloom Filters this way as an interim approach until ProtectRS is ready.

The following updates have been made to the original code.

- Updates to use Protect::Error
- Removes defaults for m & k, will raise error instead of providing default value.
- Modifies specs to take into account no default values. Add's test to check error is raised if no default value provided.