### PR TITLE
Remove accidentally-committed :focus in specs

### DIFF
--- a/spec/protect/dsl_spec.rb
+++ b/spec/protect/dsl_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Protect::Model::DSL do
         }.to_not raise_error
       end
 
-      context "when a secure_search attribute does not exist", :focus do
+      context "when a secure_search attribute does not exist" do
         it "raises an error if there are no pending migrations" do
           expect {
             Class.new(ActiveRecord::Base) do


### PR DESCRIPTION
Oops, this one was me.