### PR TITLE
Complain in CI if we've left a :focus in somewhere.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,25 @@ RSpec.configure do |config|
   config.full_backtrace = ENV.key?("RSPEC_FULL_BACKTRACE")
   config.run_all_when_everything_filtered = true
 
+  if ENV.has_key?('CI')
+    # Yell if we're filtering in CI, eg. we've filtered on ':focus' somewhere by accident.
+    config.before(:suite) do
+      run_examples = RSpec.world.example_count
+      all_examples = RSpec.world.all_examples.count
+      if run_examples != all_examples
+        paths = RSpec.world.filtered_examples.flat_map(&:second).map(&:file_path).uniq.sort
+        msg = <<~EOF
+          Examples have been filtered; you're only running #{run_examples} out of #{all_examples} examples.
+
+          You may have left a filter (eg. :focus) in one of your *_spec.rb
+          files; is it one of these?
+          #{paths.map { |p| "- #{p}" }.join("\n")}
+        EOF
+        raise msg
+      end
+    end
+  end
+
   config.backtrace_inclusion_patterns = [
     /\/lib\/protect/,
     /\/spec\/protect/,


### PR DESCRIPTION
Just a quick one; this technically works independently of #35, but isn't terribly useful without it.

![Example error message from spec_helper](https://user-images.githubusercontent.com/133028/204707581-765f9e5d-7d87-441b-9d8a-d248fcb6f4ee.png)
