### PR TITLE
Release cipherstash-protect v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.2.0]
+
+### Fixed
+
+- Filenames and module namespacing, now that this gem is called `cipherstash-protect`.
+
 ## [0.1.0]
 
-## Added
+### Added
 
 - Installation scripts to install custom db ore type.
 - Enable CRUD operations on encrypted columns.

--- a/lib/cipherstash/protect/version.rb
+++ b/lib/cipherstash/protect/version.rb
@@ -1,5 +1,5 @@
 module CipherStash
   module Protect
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end


### PR DESCRIPTION
### Fixed

- Filenames and module namespacing, now that this gem is called `cipherstash-protect`.