### PR TITLE
Fix tokenization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Create and update operation using bloom filters.
 
+### Fixed
+
+- Ngram tokenization to use min and max length.
+
 ## [0.2.0]
 
 ### Fixed

--- a/lib/cipherstash/protect/analysis/text_processor.rb
+++ b/lib/cipherstash/protect/analysis/text_processor.rb
@@ -51,8 +51,13 @@ module CipherStash
                 raise CipherStash::Protect::Error, "Min length and max length not provided with ngram filter. Please specify ngram token length using '{kind: :ngram, min_length: 3, max_length: 8}'"
               end
 
-              # TODO check max is >= min
-              # TODO check min and max values are integers and not nil
+              unless obj[:min_length].instance_of?(Integer) && obj[:max_length].instance_of?(Integer)
+                raise CipherStash::Protect::Error, "The values provided to the min and max length must be of type Integer."
+              end
+
+              unless obj[:max_length] >= obj[:min_length]
+                 raise CipherStash::Protect::Error, "The ngram filter min length must be less than or equal to the max length"
+              end
 
               TokenFilters::NGram.new(obj)
 

--- a/lib/cipherstash/protect/analysis/text_processor.rb
+++ b/lib/cipherstash/protect/analysis/text_processor.rb
@@ -16,7 +16,7 @@ module CipherStash
         # TextProcessor.new({
         #   token_filters: [
         #     {kind: :downcase},
-        #     {kind: :ngram, token_length: 3}
+        #     {kind: :ngram, min_length: 3, max_length: 8}
         #   ],
         #   tokenizer: {kind: :standard}
         # })
@@ -47,7 +47,12 @@ module CipherStash
               TokenFilters::Downcase.new(obj)
 
             when :ngram
-              raise CipherStash::Protect::Error, "Token length not provided. Please specify token length using '{kind: :ngram, tokenLength: 3}'" unless obj[:token_length]
+              unless obj[:min_length] && obj[:max_length]
+                raise CipherStash::Protect::Error, "Min length and max length not provided with ngram filter. Please specify ngram token length using '{kind: :ngram, min_length: 3, max_length: 8}'"
+              end
+
+              # TODO check max is >= min
+              # TODO check min and max values are integers and not nil
 
               TokenFilters::NGram.new(obj)
 

--- a/lib/cipherstash/protect/analysis/token_filters.rb
+++ b/lib/cipherstash/protect/analysis/token_filters.rb
@@ -22,6 +22,16 @@ module CipherStash
                 (token.length - token_length + 1).times do |i|
                   out << token[i, token_length]
                 end
+
+                a, b, c, *rest = token.split("")
+                init_ngram = [[a, b, c].join]
+
+                edge_ngram =
+                  rest.reduce(init_ngram) do |acc, char|
+                  acc.push(acc.last + char)
+                end
+
+                out.concat(edge_ngram)
               end
             end
           end

--- a/lib/cipherstash/protect/analysis/token_filters.rb
+++ b/lib/cipherstash/protect/analysis/token_filters.rb
@@ -16,23 +16,23 @@ module CipherStash
 
         class NGram < Base
           def perform(str_or_array)
-            token_length = @opts[:token_length]
+            min_length = @opts[:min_length]
+            max_length = @opts[:max_length]
+
             Array(str_or_array).flat_map do |token|
-              [].tap do |out|
-                (token.length - token_length + 1).times do |i|
-                  out << token[i, token_length]
+              token_length = token.length
+
+
+              ngrams = [].tap do |out|
+                (min_length..max_length).each do |n|
+                  ngram = token.chars.each_cons(n).map(&:join)
+                  out << ngram
                 end
-
-                a, b, c, *rest = token.split("")
-                init_ngram = [[a, b, c].join]
-
-                edge_ngram =
-                  rest.reduce(init_ngram) do |acc, char|
-                  acc.push(acc.last + char)
+                if token_length > max_length
+                  out << token
                 end
-
-                out.concat(edge_ngram)
               end
+              ngrams.flatten
             end
           end
         end

--- a/lib/cipherstash/protect/analysis/token_filters.rb
+++ b/lib/cipherstash/protect/analysis/token_filters.rb
@@ -22,7 +22,6 @@ module CipherStash
             Array(str_or_array).flat_map do |token|
               token_length = token.length
 
-
               ngrams = [].tap do |out|
                 (min_length..max_length).each do |n|
                   ngram = token.chars.each_cons(n).map(&:join)

--- a/lib/cipherstash/protect/analysis/token_validations.rb
+++ b/lib/cipherstash/protect/analysis/token_validations.rb
@@ -23,9 +23,10 @@ module CipherStash
         end
 
         def self.valid_token_length?(token_filters)
-          token_length = token_filters.select { |f| f.has_key?(:token_length) }
+          min_length = token_filters.select { |f| f.has_key?(:min_length ) }
+          max_length = token_filters.select { |f| f.has_key?(:max_length ) }
 
-          token_length.instance_of?(Integer)
+          min_length.instance_of?(Integer) && max_length.instance_of?(Integer) && max_length >= min_length
         end
       end
     end

--- a/spec/protect/crud/create_spec.rb
+++ b/spec/protect/crud/create_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe CipherStash::Protect::Model::CRUD do
     VALID_BLOOM_FILTER_ID = "4f108250-53f8-013b-0bb5-0e015c998818"
     FILTER_SIZE = 256
     FILTER_TERM_BITS = 3
-    TOKEN_FILTERS = [{kind: :downcase}, {kind: :ngram, token_length: 3}]
+    TOKEN_FILTERS = [{kind: :downcase}, {kind: :ngram, min_length: 3, max_length: 8}]
     TOKENIZER = { kind: :standard }
 
     let(:model) {

--- a/spec/protect/crud/update_spec.rb
+++ b/spec/protect/crud/update_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe CipherStash::Protect::Model::CRUD do
     VALID_BLOOM_FILTER_ID = "4f108250-53f8-013b-0bb5-0e015c998818"
     FILTER_SIZE = 256
     FILTER_TERM_BITS = 3
-    TOKEN_FILTERS = [{kind: :downcase}, {kind: :ngram, token_length: 3}]
+    TOKEN_FILTERS = [{kind: :downcase}, {kind: :ngram, min_length: 3, max_length: 8}]
     TOKENIZER = { kind: :standard }
 
     let(:model) {

--- a/spec/protect/dsl_spec.rb
+++ b/spec/protect/dsl_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe CipherStash::Protect::Model::DSL do
             tokenizer: { kind: :standard },
             token_filters: [
               {kind: :downcase},
-              {kind: :ngram, token_length: 3}
+              {kind: :ngram, min_length: 3, max_length: 8}
             ]
           )
         }.to raise_error(CipherStash::Protect::Error, "Invalid secure_text_search options provided in model for attribute 'full_name'.")
@@ -162,7 +162,7 @@ RSpec.describe CipherStash::Protect::Model::DSL do
             tokenizer: { kind: :standard },
             token_filters: [
               {kind: :downcase},
-              {kind: :ngram, token_length: 3}
+              {kind: :ngram, min_length: 3, max_length: 8}
             ]
           )
         }.to raise_error(CipherStash::Protect::Error, "Invalid secure_text_search options provided in model for attribute 'full_name'.")
@@ -175,7 +175,7 @@ RSpec.describe CipherStash::Protect::Model::DSL do
             tokenizer: { kind: :standard },
             token_filters: [
               {kind: :downcase},
-              {kind: :ngram, token_length: 3}
+              {kind: :ngram, min_length: 3, max_length: 8}
             ]
           )
         }.to raise_error(CipherStash::Protect::Error, "Invalid secure_text_search options provided in model for attribute 'full_name'.")
@@ -190,7 +190,7 @@ RSpec.describe CipherStash::Protect::Model::DSL do
             tokenizer: { kind: :non_standard },
             token_filters: [
               {kind: :downcase},
-              {kind: :ngram, token_length: 3}
+              {kind: :ngram, min_length: 3, max_length: 8}
             ]
           )
         }.to raise_error(CipherStash::Protect::Error, "Invalid secure_text_search options provided in model for attribute 'full_name'.")
@@ -210,7 +210,7 @@ RSpec.describe CipherStash::Protect::Model::DSL do
         }.to raise_error(CipherStash::Protect::Error, "Invalid secure_text_search options provided in model for attribute 'full_name'.")
       end
 
-      it "raises an error when an ngram filter is specified without token_length" do
+      it "raises an error when an ngram filter is specified without min_length and max_length" do
         expect {
           model.secure_text_search(
             :full_name,
@@ -225,7 +225,7 @@ RSpec.describe CipherStash::Protect::Model::DSL do
       end
 
       ["3", nil, { test: "something"}, "test", Object.new].each do |t|
-        it "raises an error when an ngram filter is specified with an invalid token_length #{t.inspect}" do
+        it "raises an error when an ngram filter is specified with an invalid min or max length #{t.inspect}" do
           expect {
             model.secure_text_search(
               :full_name,
@@ -233,11 +233,25 @@ RSpec.describe CipherStash::Protect::Model::DSL do
               filter_term_bits: 3,
               tokenizer: { kind: :standard },
               token_filters: [
-                {kind: :ngram, token_length: t}
+                {kind: :ngram, min_length: t, max_length: t}
               ]
             )
           }.to raise_error(CipherStash::Protect::Error, "Invalid secure_text_search options provided in model for attribute 'full_name'.")
         end
+      end
+
+      it "raises an error when an ngram filter max length < min length" do
+          expect {
+            model.secure_text_search(
+              :full_name,
+              filter_size: 256,
+              filter_term_bits: 3,
+              tokenizer: { kind: :standard },
+              token_filters: [
+                {kind: :ngram, min_length: 5, max_length: 4}
+              ]
+            )
+          }.to raise_error(CipherStash::Protect::Error, "Invalid secure_text_search options provided in model for attribute 'full_name'.")
       end
 
       it "raises an error if a bloom filter id is not set" do
@@ -249,7 +263,7 @@ RSpec.describe CipherStash::Protect::Model::DSL do
             tokenizer: { kind: :standard },
             token_filters: [
               {kind: :downcase},
-              {kind: :ngram, token_length: 3}
+              {kind: :ngram, min_length: 3, max_length: 8}
             ]
           )
         }.to raise_error(CipherStash::Protect::Error, "Bloom filter id has not been set. Specify 'bloom_filter_id' with a valid uuid as part of the options for attribute 'full_name'.")
@@ -265,7 +279,7 @@ RSpec.describe CipherStash::Protect::Model::DSL do
             tokenizer: { kind: :standard },
             token_filters: [
               {kind: :downcase},
-              {kind: :ngram, token_length: 3}
+              {kind: :ngram, min_length: 3, max_length: 8}
             ]
           )
         }.to raise_error(CipherStash::Protect::Error, "Bloom filter id has not been set. Specify 'bloom_filter_id' with a valid uuid as part of the options for attribute 'full_name'.")
@@ -281,7 +295,7 @@ RSpec.describe CipherStash::Protect::Model::DSL do
             tokenizer: { kind: :standard },
             token_filters: [
               {kind: :downcase},
-              {kind: :ngram, token_length: 3}
+              {kind: :ngram, min_length: 3, max_length: 8}
             ]
           )
         }.to_not raise_error

--- a/spec/protect/text_processor_spec.rb
+++ b/spec/protect/text_processor_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe CipherStash::Protect::Analysis::TextProcessor do
     end
 
     ["1", { foo: "bar" }, Object.new].each do |length|
-      it "raises and error if invalid length of #{length.inspect} provided" do
+      it "raises an error if invalid length of #{length.inspect} provided" do
         expect {
           CipherStash::Protect::Analysis::TextProcessor.new({
             token_filters:[
@@ -70,7 +70,7 @@ RSpec.describe CipherStash::Protect::Analysis::TextProcessor do
       end
     end
 
-    it "raises and error if the min length is greater than the max length" do
+    it "raises an error if the min length is greater than the max length" do
       expect {
           CipherStash::Protect::Analysis::TextProcessor.new({
             token_filters:[

--- a/spec/protect/text_processor_spec.rb
+++ b/spec/protect/text_processor_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe CipherStash::Protect::Analysis::TextProcessor do
     end
   end
 
-  describe "Standard text processor with ngram filter" do
+  describe "Standard text processor with ngram and edge_ngram filter" do
     it "splits text into ngrams using token length of 3" do
       tokenizer =
         CipherStash::Protect::Analysis::TextProcessor.new({
@@ -53,8 +53,8 @@ RSpec.describe CipherStash::Protect::Analysis::TextProcessor do
           ],
           tokenizer: { kind: :standard }
         })
-      result = tokenizer.perform("This is an example of an ngram filter")
-      expect(result).to eq(["thi", "his", "exa", "xam", "amp", "mpl", "ple", "ngr", "gra", "ram", "fil", "ilt", "lte", "ter"])
+      result = tokenizer.perform("Example filter")
+      expect(result).to eq(["exa", "xam", "amp", "mpl", "ple", "exa", "exam", "examp", "exampl", "example", "fil", "ilt", "lte", "ter", "fil", "filt", "filte", "filter"])
     end
 
     it "raises an error if a token length is not provided" do

--- a/spec/protect/text_processor_spec.rb
+++ b/spec/protect/text_processor_spec.rb
@@ -44,6 +44,44 @@ RSpec.describe CipherStash::Protect::Analysis::TextProcessor do
   end
 
   describe "Standard text processor with ngram and edge_ngram filter" do
+    it "raises an error if min length and max length are not provided" do
+      expect {
+        CipherStash::Protect::Analysis::TextProcessor.new({
+          token_filters:[
+            {kind: :downcase},
+            {kind: :ngram}
+          ],
+          tokenizer: { kind: :standard }
+        })
+      }.to raise_error(CipherStash::Protect::Error, "Min length and max length not provided with ngram filter. Please specify ngram token length using '{kind: :ngram, min_length: 3, max_length: 8}'")
+    end
+
+    ["1", { foo: "bar" }, Object.new].each do |length|
+      it "raises and error if invalid length of #{length.inspect} provided" do
+        expect {
+          CipherStash::Protect::Analysis::TextProcessor.new({
+            token_filters:[
+              {kind: :downcase},
+              {kind: :ngram, min_length: length, max_length: length}
+            ],
+            tokenizer: { kind: :standard }
+          })
+        }.to raise_error(CipherStash::Protect::Error, "The values provided to the min and max length must be of type Integer.")
+      end
+    end
+
+    it "raises and error if the min length is greater than the max length" do
+      expect {
+          CipherStash::Protect::Analysis::TextProcessor.new({
+            token_filters:[
+              {kind: :downcase},
+              {kind: :ngram, min_length: 6, max_length: 5}
+            ],
+            tokenizer: { kind: :standard }
+          })
+        }.to raise_error(CipherStash::Protect::Error, "The ngram filter min length must be less than or equal to the max length")
+    end
+
     it "splits text into ngrams using min length of 3 and max length of 8" do
       tokenizer =
         CipherStash::Protect::Analysis::TextProcessor.new({
@@ -105,18 +143,6 @@ RSpec.describe CipherStash::Protect::Analysis::TextProcessor do
           "connection"
         ]
       )
-    end
-
-    it "raises an error if min length and max length are not provided" do
-      expect {
-        CipherStash::Protect::Analysis::TextProcessor.new({
-          token_filters:[
-            {kind: :downcase},
-            {kind: :ngram}
-          ],
-          tokenizer: { kind: :standard }
-        })
-      }.to raise_error(CipherStash::Protect::Error, "Min length and max length not provided with ngram filter. Please specify ngram token length using '{kind: :ngram, min_length: 3, max_length: 8}'")
     end
   end
 end

--- a/spec/protect/text_processor_spec.rb
+++ b/spec/protect/text_processor_spec.rb
@@ -44,20 +44,70 @@ RSpec.describe CipherStash::Protect::Analysis::TextProcessor do
   end
 
   describe "Standard text processor with ngram and edge_ngram filter" do
-    it "splits text into ngrams using token length of 3" do
+    it "splits text into ngrams using min length of 3 and max length of 8" do
       tokenizer =
         CipherStash::Protect::Analysis::TextProcessor.new({
           token_filters:[
             {kind: :downcase},
-            {kind: :ngram, token_length: 3}
+            {kind: :ngram, min_length: 3, max_length: 8}
           ],
           tokenizer: { kind: :standard }
         })
-      result = tokenizer.perform("Example filter")
-      expect(result).to eq(["exa", "xam", "amp", "mpl", "ple", "exa", "exam", "examp", "exampl", "example", "fil", "ilt", "lte", "ter", "fil", "filt", "filte", "filter"])
+      result = tokenizer.perform("Example")
+      expect(result).to eq(["exa", "xam", "amp", "mpl", "ple", "exam", "xamp", "ampl", "mple", "examp", "xampl", "ample", "exampl", "xample", "example"])
     end
 
-    it "raises an error if a token length is not provided" do
+    it "returns ngrams including whole token if token length > max token length" do
+      tokenizer =
+        CipherStash::Protect::Analysis::TextProcessor.new({
+          token_filters:[
+            {kind: :downcase},
+            {kind: :ngram, min_length: 3, max_length: 8}
+          ],
+          tokenizer: { kind: :standard }
+        })
+      result = tokenizer.perform("Connection")
+      expect(result).to eq(
+        [
+          "con",
+          "onn",
+          "nne",
+          "nec",
+          "ect",
+          "cti",
+          "tio",
+          "ion",
+          "conn",
+          "onne",
+          "nnec",
+          "nect",
+          "ecti",
+          "ctio",
+          "tion",
+          "conne",
+          "onnec",
+          "nnect",
+          "necti",
+          "ectio",
+          "ction",
+          "connec",
+          "onnect",
+          "nnecti",
+          "nectio",
+          "ection",
+          "connect",
+          "onnecti",
+          "nnectio",
+          "nection",
+          "connecti",
+          "onnectio",
+          "nnection",
+          "connection"
+        ]
+      )
+    end
+
+    it "raises an error if min length and max length are not provided" do
       expect {
         CipherStash::Protect::Analysis::TextProcessor.new({
           token_filters:[
@@ -66,7 +116,7 @@ RSpec.describe CipherStash::Protect::Analysis::TextProcessor do
           ],
           tokenizer: { kind: :standard }
         })
-      }.to raise_error(CipherStash::Protect::Error, "Token length not provided. Please specify token length using '{kind: :ngram, tokenLength: 3}'")
+      }.to raise_error(CipherStash::Protect::Error, "Min length and max length not provided with ngram filter. Please specify ngram token length using '{kind: :ngram, min_length: 3, max_length: 8}'")
     end
   end
 end


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-ngram-tokenizer.html#_example_configuration_8

https://www.notion.so/cipherstash/Bug-Text-query-false-positives-4ded8023f76e4bac869bca71cbad3c14

Updates text processor to generate ngrams with a min and max length.

If token is greater than the max length, then the whole token is added. This will be used for exact matches.

