### PR TITLE
Rearrange the protect library a little to aid in predictability and consistency.

### DIFF
--- a/lib/cipherstash/protect/active_record_extensions.rb
+++ b/lib/cipherstash/protect/active_record_extensions.rb
@@ -1,33 +1,5 @@
-require "active_support"
+require_relative "./active_record_extensions/dynamic_matchers"
 require_relative "./active_record_extensions/ore_64_8_v1"
+require_relative "./active_record_extensions/predicate_builder"
+require_relative "./active_record_extensions/query_methods"
 require_relative "./active_record_extensions/uniqueness_validator"
-require_relative "./database_extensions/postgresql"
-
-# TODO: Move these into ActiveRecordExtensions as well for consistency's sake.
-require_relative "./model/dynamic_matchers"
-require_relative "./model/predicate_builder"
-require_relative "./model/query_methods"
-
-if defined?(ActiveSupport.on_load)
-  ActiveSupport.on_load(:active_record) do
-    ActiveRecord::Base.include CipherStash::Protect::Model
-
-    ActiveRecord::DynamicMatchers::Method.prepend(CipherStash::Protect::Model::DynamicMatchers)
-    ActiveRecord::PredicateBuilder.prepend(CipherStash::Protect::Model::PredicateBuilder)
-    ActiveRecord::Relation.prepend(CipherStash::Protect::Model::QueryMethods)
-    ActiveRecord::Validations::UniquenessValidator.prepend(CipherStash::Protect::ActiveRecordExtensions::UniquenessValidator)
-
-    require "active_record/connection_adapters/postgresql_adapter"
-
-    ActiveRecord::Type.register(
-      "ore_64_8_v1",
-      CipherStash::Protect::ActiveRecordExtensions::ORE_64_8_V1_Type,
-      override: true,
-      adapter: :postgresql
-    )
-
-    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend(
-      CipherStash::Protect::DatabaseExtensions::Postgresql::ConnectionAdapter
-    )
-  end
-end

--- a/lib/cipherstash/protect/active_record_extensions/dynamic_matchers.rb
+++ b/lib/cipherstash/protect/active_record_extensions/dynamic_matchers.rb
@@ -1,6 +1,6 @@
 module CipherStash
   module Protect
-    module Model
+    module ActiveRecordExtensions
       module DynamicMatchers
         def valid?
           attribute_names.all? { |name|

--- a/lib/cipherstash/protect/active_record_extensions/ore_64_8_v1.rb
+++ b/lib/cipherstash/protect/active_record_extensions/ore_64_8_v1.rb
@@ -1,3 +1,5 @@
+require 'ore-rs'
+
 module CipherStash
   module Protect
     module ActiveRecordExtensions

--- a/lib/cipherstash/protect/active_record_extensions/predicate_builder.rb
+++ b/lib/cipherstash/protect/active_record_extensions/predicate_builder.rb
@@ -1,6 +1,6 @@
 module CipherStash
   module Protect
-    module Model
+    module ActiveRecordExtensions
       module PredicateBuilder
         include CipherStash::Protect::ActiveRecordExtensions
 

--- a/lib/cipherstash/protect/active_record_extensions/query_methods.rb
+++ b/lib/cipherstash/protect/active_record_extensions/query_methods.rb
@@ -1,6 +1,6 @@
 module CipherStash
   module Protect
-    module Model
+    module ActiveRecordExtensions
       module QueryMethods
         # Intercepts the order call to update any virtual attributes to use the
         # searchable attribute field.

--- a/lib/cipherstash/protect/analysis.rb
+++ b/lib/cipherstash/protect/analysis.rb
@@ -1,0 +1,4 @@
+require_relative './analysis/text_processor'
+require_relative './analysis/token_filters'
+require_relative './analysis/token_validations'
+require_relative './analysis/tokenizer'

--- a/lib/cipherstash/protect/analysis/text_processor.rb
+++ b/lib/cipherstash/protect/analysis/text_processor.rb
@@ -1,6 +1,3 @@
-require_relative "./token_filters"
-require_relative "./tokenizer"
-
 # Implementation copied over from the Ruby Client
 # https://github.com/cipherstash/ruby-client/blob/main/lib/cipherstash/analysis/text_processor.rb
 module CipherStash

--- a/lib/cipherstash/protect/database_extensions.rb
+++ b/lib/cipherstash/protect/database_extensions.rb
@@ -1,3 +1,5 @@
+require_relative "./database_extensions/postgresql"
+
 module CipherStash
   module Protect
     module DatabaseExtensions

--- a/lib/cipherstash/protect/model.rb
+++ b/lib/cipherstash/protect/model.rb
@@ -1,4 +1,6 @@
 require "active_support/concern"
+require "lockbox"
+
 require_relative "./model/dsl"
 require_relative "./model/crud"
 
@@ -6,6 +8,7 @@ module CipherStash
   module Protect
     module Model
       extend ActiveSupport::Concern
+
       include CipherStash::Protect::Model::DSL
       include CipherStash::Protect::Model::CRUD
 

--- a/lib/cipherstash/protect/model/crud.rb
+++ b/lib/cipherstash/protect/model/crud.rb
@@ -1,6 +1,4 @@
 require "active_support/concern"
-require "cipherstash/protect/active_record_extensions/bloom_filter"
-require "cipherstash/protect/analysis/text_processor"
 
 module CipherStash
   module Protect
@@ -97,7 +95,7 @@ module CipherStash
         private
 
         def self.filter_bits(bloom_filter_id, filter_options, value)
-          filter = CipherStash::Protect::ActiveRecordExtensions::BloomFilter.new(bloom_filter_id, { filter_size: filter_options[:filter_size], filter_term_bits: filter_options[:filter_term_bits] })
+          filter = CipherStash::Protect::Query::BloomFilter.new(bloom_filter_id, { filter_size: filter_options[:filter_size], filter_term_bits: filter_options[:filter_term_bits] })
 
           text_processor = CipherStash::Protect::Analysis::TextProcessor.new({
             token_filters: filter_options[:token_filters],

--- a/lib/cipherstash/protect/model/dsl.rb
+++ b/lib/cipherstash/protect/model/dsl.rb
@@ -1,9 +1,6 @@
 require "active_support/concern"
 require "uuid"
 
-require_relative "../active_record_extensions/bloom_filter_validations"
-require_relative "../analysis/token_validations"
-
 module CipherStash
   module Protect
     module Model
@@ -137,11 +134,11 @@ module CipherStash
           end
 
           def bloom_filter_settings?(options)
-            valid_filter_options = Protect::ActiveRecordExtensions::BloomFilterValidations.valid_filter_options?(options)
+            valid_filter_options = Protect::Query::BloomFilterValidations.valid_filter_options?(options)
             m = options.fetch(:filter_size, nil)
             k = options.fetch(:filter_term_bits, nil)
 
-            valid_filter_options && Protect::ActiveRecordExtensions::BloomFilterValidations.valid_m?(m) && Protect::ActiveRecordExtensions::BloomFilterValidations.valid_k?(k)
+            valid_filter_options && Protect::Query::BloomFilterValidations.valid_m?(m) && Protect::Query::BloomFilterValidations.valid_k?(k)
           end
 
           def text_analysis_settings?(options)

--- a/lib/cipherstash/protect/query.rb
+++ b/lib/cipherstash/protect/query.rb
@@ -1,0 +1,2 @@
+require_relative "./query/bloom_filter"
+require_relative "./query/bloom_filter_validations"

--- a/lib/cipherstash/protect/query/bloom_filter.rb
+++ b/lib/cipherstash/protect/query/bloom_filter.rb
@@ -1,10 +1,9 @@
 require "hkdf"
 require "openssl"
-require_relative "./bloom_filter_validations"
 
 module CipherStash
   module Protect
-    module ActiveRecordExtensions
+    module Query
       # A bloom filter implementation designed to be used with *secure_text_search fields
       class BloomFilter
         # The min and max values for k and m:

--- a/lib/cipherstash/protect/query/bloom_filter_validations.rb
+++ b/lib/cipherstash/protect/query/bloom_filter_validations.rb
@@ -1,6 +1,6 @@
 module CipherStash
   module Protect
-    module ActiveRecordExtensions
+    module Query
       module BloomFilterValidations
         M_MIN = 32
         M_MAX = 65536

--- a/spec/protect/bloom_filter_spec.rb
+++ b/spec/protect/bloom_filter_spec.rb
@@ -1,6 +1,4 @@
-require "cipherstash/protect/active_record_extensions/bloom_filter"
-
-RSpec.describe CipherStash::Protect::ActiveRecordExtensions::BloomFilter do
+RSpec.describe CipherStash::Protect::Query::BloomFilter do
   self::VALID_M_VALUES = [32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536]
   self::VALID_K_VALUES = [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
 

--- a/spec/protect/crud/create_spec.rb
+++ b/spec/protect/crud/create_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe CipherStash::Protect::Model::CRUD do
     }
 
     let(:filter) {
-      CipherStash::Protect::ActiveRecordExtensions::BloomFilter.new(VALID_BLOOM_FILTER_ID,
+      CipherStash::Protect::Query::BloomFilter.new(VALID_BLOOM_FILTER_ID,
         {
           filter_size: FILTER_SIZE,
           filter_term_bits: FILTER_TERM_BITS

--- a/spec/protect/crud/update_spec.rb
+++ b/spec/protect/crud/update_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe CipherStash::Protect::Model::CRUD do
     }
 
     let(:filter) {
-      CipherStash::Protect::ActiveRecordExtensions::BloomFilter.new(VALID_BLOOM_FILTER_ID,
+      CipherStash::Protect::Query::BloomFilter.new(VALID_BLOOM_FILTER_ID,
         {
           filter_size: FILTER_SIZE,
           filter_term_bits: FILTER_TERM_BITS

--- a/spec/protect/text_processor_spec.rb
+++ b/spec/protect/text_processor_spec.rb
@@ -1,5 +1,3 @@
-require 'cipherstash/protect/analysis/text_processor'
-
 RSpec.describe CipherStash::Protect::Analysis::TextProcessor do
   describe "Standard text processor" do
     it "splits text based on word boundaries" do


### PR DESCRIPTION
Off the back of this confusion:
https://www.notion.so/cipherstash/Figure-out-strange-respond_to-requiring-errors-cccadec1dda5400784e92d18ce39135c

This PR rearranges things to try to avoid accidental reliance on the Rails autoloader by:
- Having all library code be loaded on initial `require()`,
- Having top-level files be responsible for loading the code in related subdirectories (eg. have `model.rb` load `model/*`, `analysis.rb` load `analysis/...`, etc).
- Confining side-effects when `require()`-ing to exactly one file: `lib/cipherstash/protect.rb`

The resulting file tree looks like:
```
lib
├── cipherstash-protect.rb
└── cipherstash
    ├── protect.rb
    └── protect
        ├── active_record_extensions.rb
        ├── active_record_extensions
        │   ├── dynamic_matchers.rb
        │   ├── ore_64_8_v1.rb
        │   ├── predicate_builder.rb
        │   ├── query_methods.rb
        │   └── uniqueness_validator.rb
        ├── analysis.rb
        ├── analysis
        │   ├── text_processor.rb
        │   ├── token_filters.rb
        │   ├── token_validations.rb
        │   └── tokenizer.rb
        ├── database_extensions.rb
        ├── database_extensions
        │   ├── postgresql.rb
        │   └── postgresql
        │       ├── install.sql
        │       └── uninstall.sql
        ├── logger.rb
        ├── model.rb
        ├── model
        │   ├── crud.rb
        │   └── dsl.rb
        ├── query.rb
        ├── query
        │   ├── bloom_filter.rb
        │   └── bloom_filter_validations.rb
        ├── railtie.rb
        └── version.rb
```

Thoughts? (I'm not at all wed to this, and the changes are easy enough to replay so please don't worry about ordering of PRs.)