### PR TITLE
Text match querying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Create and update operation using bloom filters.
+- Text match querying using bloom filters.
 
 ### Fixed
 

--- a/lib/cipherstash/protect/model/crud.rb
+++ b/lib/cipherstash/protect/model/crud.rb
@@ -66,10 +66,10 @@ module CipherStash
             end
 
             virt_attr = arg.keys.first
-            searchable_text_attr = protect_search_attrs[virt_attr].fetch(:searchable_text_attribute)&.keys&.first
+            searchable_text_attr = protect_search_attrs[virt_attr]&.fetch(:searchable_text_attribute, nil)&.keys&.first
 
             unless searchable_text_attr
-              raise CipherStash::Protect::Error, "Unable to execute text match query. Attribute does not have a secure_text_search column."
+              raise CipherStash::Protect::Error, "Unable to execute text match query. Attribute: #{virt_attr.to_s} does not have a secure_text_search column."
             end
 
             filter_options = protect_search_attrs[virt_attr][:searchable_text_attribute].fetch(searchable_text_attr)

--- a/lib/cipherstash/protect/model/crud.rb
+++ b/lib/cipherstash/protect/model/crud.rb
@@ -57,7 +57,6 @@ module CipherStash
           end
 
           def match(arg = {})
-            # binding.pry
             unless arg.size == 1
               raise CipherStash::Protect::Error, "Unable to execute text match query. Incorrect args passed. Example usage: model.match(email: 'test')"
             end

--- a/spec/protect/crud/read_spec.rb
+++ b/spec/protect/crud/read_spec.rb
@@ -566,7 +566,7 @@ RSpec.describe CipherStash::Protect::Model::CRUD do
         end
       end
 
-      it "raises and error if a match query is made on an attribute that isn't a searchabl text attribute" do
+      it "raises error if a match query is made on an attribute that isn't a searchabl text attribute" do
         expect {
           model_without_secure_text_search.match(full_name: "John")
         }.to raise_error(CipherStash::Protect::Error, "Unable to execute text match query. Attribute: full_name does not have a secure_text_search column.")

--- a/spec/protect/crud/read_spec.rb
+++ b/spec/protect/crud/read_spec.rb
@@ -586,7 +586,7 @@ RSpec.describe CipherStash::Protect::Model::CRUD do
         end
       end
 
-      it "raises error if a match query is made on an attribute that isn't a searchabl text attribute" do
+      it "raises error if a match query is made on an attribute that isn't a searchable text attribute" do
         expect {
           model_without_secure_text_search.match(full_name: "John")
         }.to raise_error(CipherStash::Protect::Error, "Unable to execute text match query. Attribute: full_name does not have a secure_text_search column.")
@@ -635,6 +635,39 @@ RSpec.describe CipherStash::Protect::Model::CRUD do
         expect(sorted_users.first.email).to eq("danna@cummings.info")
         expect(sorted_users.second.email).to eq("dannie@hahn.name")
         expect(sorted_users.last.email).to eq("greta@gerwig.com")
+      end
+
+      it "returns records using a match query with multiple args" do
+         model_multiple_field_search.insert_all([
+          { suburb: "Sydney", email: "marybeth@kertzmann-bailey.org" },
+          { suburb: "Blaxland", email: "mariann@williamson.org" },
+          { suburb: "Sydney", email: "marissa@hartmann.com" },
+          { suburb: "Nowra", email: "dannie@hahn.name" },
+          { suburb: "Parramatta", email: "greta@gerwig.com" },
+          { suburb: "Strathfield", email: "danna@cummings.info" },
+        ])
+        users = model_multiple_field_search.match(email: "mary", suburb: "syd")
+        sorted_users = users.sort_by { |u| u.email}
+
+        expect(sorted_users.length).to eq(1)
+        expect(sorted_users.first.email).to eq("marybeth@kertzmann-bailey.org")
+      end
+
+      it "returns records using a match query with multiple args chained to an or query" do
+        model_multiple_field_search.insert_all([
+          { suburb: "Sydney", email: "marybeth@kertzmann-bailey.org" },
+          { suburb: "Blaxland", email: "mariann@williamson.org" },
+          { suburb: "Sydney", email: "marissa@hartmann.com" },
+          { suburb: "Nowra", email: "dannie@hahn.name" },
+          { suburb: "Parramatta", email: "greta@gerwig.com" },
+          { suburb: "Strathfield", email: "danna@cummings.info" },
+        ])
+        users = model_multiple_field_search.match(email: "mary", suburb: "syd").or(model_multiple_field_search.match(email: "dann", suburb: "strat"))
+        sorted_users = users.sort_by { |u| u.email}
+
+        expect(sorted_users.length).to eq(2)
+        expect(sorted_users.first.email).to eq("danna@cummings.info")
+        expect(sorted_users.second.email).to eq("marybeth@kertzmann-bailey.org")
       end
 
       it "returns records using a match query on multiple fields with or" do

--- a/spec/protect/crud/read_spec.rb
+++ b/spec/protect/crud/read_spec.rb
@@ -544,6 +544,12 @@ RSpec.describe CipherStash::Protect::Model::CRUD do
       end
     }
 
+    let(:model_without_secure_text_search) {
+      Class.new(ActiveRecord::Base) do
+        self.table_name = CrudTesting.table_name
+      end
+    }
+
     context "when using a match query" do
       it "raises an error if no query arg is passed" do
         expect {
@@ -558,6 +564,12 @@ RSpec.describe CipherStash::Protect::Model::CRUD do
             model.match(email: type)
           }.to raise_error(CipherStash::Protect::Error, "Value passed to match query must be of type String. Got #{type.inspect()}.")
         end
+      end
+
+      it "raises and error if a match query is made on an attribute that isn't a searchabl text attribute" do
+        expect {
+          model_without_secure_text_search.match(full_name: "John")
+        }.to raise_error(CipherStash::Protect::Error, "Unable to execute text match query. Attribute: full_name does not have a secure_text_search column.")
       end
 
       it "returns records when using partial string as value" do

--- a/spec/protect/dsl_spec.rb
+++ b/spec/protect/dsl_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe CipherStash::Protect::Model::DSL do
   describe "class_methods" do
     context "secure_search" do
+      let(:valid_bloom_filter_id) { "4f108250-53f8-013b-0bb5-0e015c998818" }
       let(:model) {
         Class.new(ActiveRecord::Base) do
           self.table_name = DslTesting.table_name
@@ -32,7 +33,7 @@ RSpec.describe CipherStash::Protect::Model::DSL do
           :full_name,
           filter_size: 256,
           filter_term_bits: 3,
-          bloom_filter_id: VALID_BLOOM_FILTER_ID,
+          bloom_filter_id: valid_bloom_filter_id,
           tokenizer: { kind: :standard },
           token_filters: [
             {kind: :downcase}
@@ -83,8 +84,7 @@ RSpec.describe CipherStash::Protect::Model::DSL do
     end
 
     context "secure_text_search" do
-      VALID_BLOOM_FILTER_ID = "4f108250-53f8-013b-0bb5-0e015c998818"
-
+      let(:valid_bloom_filter_id) { "4f108250-53f8-013b-0bb5-0e015c998818" }
       let(:model) {
         Class.new(ActiveRecord::Base) do
           self.table_name = DslTesting.table_name
@@ -95,17 +95,15 @@ RSpec.describe CipherStash::Protect::Model::DSL do
         Class.new(ActiveRecord::Base) do
           self.table_name = DslTesting.table_name
 
-          secure_text_search(
-            :full_name,
+          secure_text_search :full_name,
             filter_size: 256,
             filter_term_bits: 3,
-            bloom_filter_id: VALID_BLOOM_FILTER_ID,
+            bloom_filter_id: "4f108250-53f8-013b-0bb5-0e015c998818",
             tokenizer: { kind: :standard },
             token_filters: [
               {kind: :downcase},
               {kind: :ngram, token_length: 3}
             ]
-          )
         end
       }
 
@@ -291,7 +289,7 @@ RSpec.describe CipherStash::Protect::Model::DSL do
             :full_name,
             filter_size: 256,
             filter_term_bits: 3,
-            bloom_filter_id: VALID_BLOOM_FILTER_ID,
+            bloom_filter_id: valid_bloom_filter_id,
             tokenizer: { kind: :standard },
             token_filters: [
               {kind: :downcase},
@@ -307,7 +305,7 @@ RSpec.describe CipherStash::Protect::Model::DSL do
             :full_name,
             filter_size: 256,
             filter_term_bits: 3,
-            bloom_filter_id: VALID_BLOOM_FILTER_ID,
+            bloom_filter_id: valid_bloom_filter_id,
             tokenizer: { kind: :standard },
             token_filters: [
               {kind: :downcase}
@@ -321,7 +319,7 @@ RSpec.describe CipherStash::Protect::Model::DSL do
           :full_name,
           filter_size: 256,
           filter_term_bits: 3,
-          bloom_filter_id: VALID_BLOOM_FILTER_ID,
+          bloom_filter_id: valid_bloom_filter_id,
           tokenizer: { kind: :standard },
           token_filters: [
             {kind: :downcase}
@@ -334,7 +332,7 @@ RSpec.describe CipherStash::Protect::Model::DSL do
           :full_name_secure_text_search=>{
             :filter_size=>256,
             :filter_term_bits=>3,
-            :bloom_filter_id=>VALID_BLOOM_FILTER_ID,
+            :bloom_filter_id=>valid_bloom_filter_id,
             :tokenizer=>{:kind=>:standard},
             :token_filters=>[
               {:kind=>:downcase}
@@ -349,7 +347,7 @@ RSpec.describe CipherStash::Protect::Model::DSL do
           :full_name,
           filter_size: 256,
           filter_term_bits: 3,
-          bloom_filter_id: VALID_BLOOM_FILTER_ID,
+          bloom_filter_id: valid_bloom_filter_id,
           tokenizer: { kind: :standard },
           token_filters: [
             {kind: :downcase}

--- a/spec/support/migrations/300_create_users_table_for_crud_testing.rb
+++ b/spec/support/migrations/300_create_users_table_for_crud_testing.rb
@@ -1,6 +1,7 @@
 class CreateUsersTableForCrudTesting < ActiveRecord::Migration[RAILS_VERSION]
   def change
     create_table :users_for_crud_testing do |t|
+      t.text :full_name
       t.text :email_ciphertext
       t.text :dob_ciphertext
       t.text :last_login_ciphertext

--- a/spec/support/migrations/300_create_users_table_for_crud_testing.rb
+++ b/spec/support/migrations/300_create_users_table_for_crud_testing.rb
@@ -2,15 +2,19 @@ class CreateUsersTableForCrudTesting < ActiveRecord::Migration[RAILS_VERSION]
   def change
     create_table :users_for_crud_testing do |t|
       t.text :full_name
+
       t.text :email_ciphertext
       t.text :dob_ciphertext
       t.text :last_login_ciphertext
       t.text :age_ciphertext
       t.text :verified_ciphertext
       t.text :latitude_ciphertext
+      t.text :suburb_ciphertext
 
       t.column :email_secure_search, :ore_64_8_v1
       t.column :email_secure_text_search, :integer, limit: 2, array: true
+      t.column :suburb_secure_search, :ore_64_8_v1
+      t.column :suburb_secure_text_search, :integer, limit: 2, array: true
 
       t.column :dob_secure_search, :ore_64_8_v1
       t.column :last_login_secure_search, :ore_64_8_v1


### PR DESCRIPTION
Adds a custom method called `match` to the model class methods.

I took this approach, as after digging around in ActiveRecord I couldn't figure out a way to do this transparently with ActiveRecord like we have up until now. But would appreciate any feedback/advice if anyone has any other ideas on this.

This calls a where query on the model, using the postgres contains operator `@>`. A bloom filter is generated from the value using the filter settings provided in the dsl.

Usage `model.match(email: "test")`.

The method checks:
- value is a string
- accepts 1 arg
- checks attribute is a searchable text attribute

I was using constant variables in some tests, i've updated these to use let vars in the setup, as I found that there was some pollution between tests with filter settings when using constants.
