### PR TITLE
Adds PRP checking to compare_ore_64_8_v1(ore_64_8_v1, ore_64_8_v1)

### DIFF
--- a/lib/cipherstash/protect/database_extensions/postgresql/install.sql
+++ b/lib/cipherstash/protect/database_extensions/postgresql/install.sql
@@ -34,9 +34,16 @@ CREATE OR REPLACE FUNCTION compare_ore_64_8_v1(a ore_64_8_v1, b ore_64_8_v1) ret
     END IF;
 
     FOR block IN 0..7 LOOP
-      -- TODO: This isn't complete: need to check the prp values as well as the blocks
-      -- Substr is ordinally indexed (hence 9 and not 8)
-      IF substr(a.bytes, 9 + left_block_size * block, left_block_size) != substr(b.bytes, 9 + left_block_size * BLOCK, left_block_size) THEN
+      -- Compare each PRP (byte from the first 8 bytes) and PRF block (8 byte
+      -- chunks of the rest of the value).
+      -- NOTE:
+      -- * Substr is ordinally indexed (hence 1 and not 0, and 9 and not 8).
+      -- * We are not worrying about timing attacks here; don't fret about
+      --   the OR or !=.
+      IF
+        substr(a.bytes, 1 + block, 1) != substr(b.bytes, 1 + block, 1)
+        OR substr(a.bytes, 9 + left_block_size * block, left_block_size) != substr(b.bytes, 9 + left_block_size * BLOCK, left_block_size)
+      THEN
         -- set the first unequal block we find
         IF eq THEN
           unequal_block := block;


### PR DESCRIPTION
**Edit**: I have used a bunch of 1s and 0s, but each 1 and 0 is actually representing a **byte**, sorry.

The first eight bytes of each left value is a set of PRPs, one for each 8-byte PRF block, eg.

<img width="1036" alt="Screen Shot 2023-01-03 at 3 05 04 pm" src="https://user-images.githubusercontent.com/133028/210299307-64192c75-44af-427c-b82c-7739521e03a4.png">
 
This PR adds the per-block check for each of the PRP bytes, in the unlikely event that the PRPs differ but the PRF blocks don't.

For example, first block check:
<img width="1048" alt="Screen Shot 2023-01-03 at 3 05 04 pm copy 2" src="https://user-images.githubusercontent.com/133028/210299354-19da7c92-7961-4af9-bdaf-d729a809c5c8.png">

Second block check: 
<img width="1048" alt="Screen Shot 2023-01-03 at 3 05 04 pm copy" src="https://user-images.githubusercontent.com/133028/210299363-8c69c74c-3901-4656-95e1-4c206efc22be.png">

... etc.