### PR TITLE
Basic precision recall test

### DIFF
--- a/lib/cipherstash/protect/query.rb
+++ b/lib/cipherstash/protect/query.rb
@@ -1,2 +1,3 @@
 require_relative "./query/bloom_filter"
 require_relative "./query/bloom_filter_validations"
+require_relative "./query/match_query_statistics"

--- a/lib/cipherstash/protect/query/match_query_statistics.rb
+++ b/lib/cipherstash/protect/query/match_query_statistics.rb
@@ -1,0 +1,117 @@
+module CipherStash
+  module Protect
+    module Query
+      class MatchQueryStatistics
+        # Class for generating precision and recall statistics
+        # for match queries on a model.
+        #
+        # The secure_text_search method on the model uses a probabilistic
+        # data structure called a bloom filter to store the data in.
+        # https://en.wikipedia.org/wiki/Bloom_filter
+        #
+        # When encrypting the plaintext value into the secure_text_search field
+        # 2 options are required to generate the bloom filter,
+        # filter_size (m value) and filter_term_bits (k value)
+        #
+        # ## Example
+        #
+        # secure_text_search :email,
+        #   filter_size: 1024, filter_term_bits: 6,
+        #   bloom_filter_id: "4f108250-53f8-013b-0bb5-0e015c998817",
+        #   tokenizer: { kind: :standard },
+        #   token_filters: [{kind: :downcase}, {kind: :ngram, min_length: 3, max_length: 8}]
+        #
+        # To assist with determining what to provide for these options. This
+        # class returns the below statistics.
+        #
+        # Precision = relevant documents retrieved / retrieved documents
+        # Recall = relevant documents retrieved / relevant documents
+        #
+        # The precision statistic shows us how many of the total retrieved documents are relevant.
+        # The recall statistic shows us how many of the total relevant documents have been retrieved.
+        #
+        # @param model [Class] The relevant model to apply the query to.
+        #
+        # @param field [Symbol] The secure_text_search field to query.
+        #
+        # @param query_string [String] The string to use for the query to return
+        # statistic to.
+        #
+        # ## Example
+        #
+        # CipherStash::Protect::Query::MatchQueryStatistics.new({model: User, field: :email, query_string: "dann"})
+        #
+        def initialize(args = {})
+          @model = args[:model].instance_of?(String) ? args[:model].constantize : args[:model]
+          @field = args[:field].to_sym
+          @query_string = args[:query_string]
+        end
+
+        def run
+          retrieved_records = @model.match(@field => @query_string)
+
+          relevant_records = retrieve_relevant_records(retrieved_records)
+
+          relevant_retrieved_records = retrieved_records.map {|r| {id: r.id, @field => r[@field]}} & relevant_records
+
+          total_relevant_records = total_relevant_records()
+
+          precision = ((relevant_retrieved_records.length.to_f / retrieved_records.length) * 100).round(2)
+          recall = ((relevant_retrieved_records.length.to_f / total_relevant_records.length) * 100).round(2)
+
+          { precision: precision, recall: recall, retrieved_records: retrieved_records.map { |r| r[@field]}, total_relevant_records: total_relevant_records.map { |r| r[@field]}}
+        end
+
+        # Manually check the relevant records from the retrieved records
+        # using the plaintext values for the field and the plaintext tokens.
+        def retrieve_relevant_records(retrieved_records)
+          searchable_text_attr = @model.protect_search_attrs[@field][:searchable_text_attribute].keys.first
+
+          filter_options = @model.protect_search_attrs[@field][:searchable_text_attribute].fetch(searchable_text_attr)
+
+          tokens = tokenize(@query_string, filter_options)
+
+          records = retrieved_records.map { |r| {id: r.id, @field => r[@field] }}
+
+          records.filter do |r|
+            valid_tokens =
+              tokens.filter do |t|
+              r[@field].include?(t)
+            end
+            valid_tokens.length == tokens.length
+          end
+        end
+
+        # Manually look up all records, then filter records using
+        # the plaintext tokens and check that all tokens are present within each
+        # plaintext field in each record.
+        def total_relevant_records()
+          searchable_text_attr = @model.protect_search_attrs[@field][:searchable_text_attribute].keys.first
+
+          filter_options = @model.protect_search_attrs[@field][:searchable_text_attribute].fetch(searchable_text_attr)
+
+          tokens = tokenize(@query_string, filter_options)
+
+          records = @model.all
+
+           records.filter do |r|
+            valid_tokens =
+              tokens.filter do |t|
+              r[@field].include?(t)
+            end
+            valid_tokens.length == tokens.length
+          end
+        end
+
+        def tokenize(value, filter_options)
+          text_processor = CipherStash::Protect::Analysis::TextProcessor.new({
+            token_filters: filter_options[:token_filters],
+            tokenizer: filter_options[:tokenizer]
+          })
+
+          text_processor.perform(value)
+        end
+      end
+    end
+  end
+end

--- a/lib/cipherstash/protect/query/match_query_statistics.rb
+++ b/lib/cipherstash/protect/query/match_query_statistics.rb
@@ -30,6 +30,10 @@ module CipherStash
         # The precision statistic shows us how many of the total retrieved documents are relevant.
         # The recall statistic shows us how many of the total relevant documents have been retrieved.
         #
+        # To test out different filter option settings, update the values in the filter_size and filter_term_bits
+        # keys in your selected model, then re encrypt your data by running the rake task
+        # rake protect:encrypt\[Model\] and run the statistics again.
+        #
         # @param model [Class] The relevant model to apply the query to.
         #
         # @param field [Symbol] The secure_text_search field to query.

--- a/lib/tasks/protect.rake
+++ b/lib/tasks/protect.rake
@@ -35,4 +35,20 @@ namespace :protect do
 
     info.split("\n").each {|line| CipherStash::Protect::Logger.info(line) }
   end
+
+  desc "Generate match query stats to help determine what filter settings to use"
+  task :match_query_stats, [:model, :field, :query_string] => :environment do |_task, args|
+    stats = CipherStash::Protect::Query::MatchQueryStatistics.new(**args.to_hash).run
+
+    info = <<~EOF
+      The precision recall stats for model #{args[:model].class.name} on field #{args[:field]}
+
+      using query_string #{args[:query_string]}:
+
+      precision = #{stats[:precision]}%
+      recall = #{stats[:recall]}%
+    EOF
+
+    info.split("\n").each {|line| CipherStash::Protect::Logger.info(line) }
+  end
 end

--- a/lib/tasks/protect.rake
+++ b/lib/tasks/protect.rake
@@ -41,14 +41,20 @@ namespace :protect do
     stats = CipherStash::Protect::Query::MatchQueryStatistics.new(**args.to_hash).run
 
     info = <<~EOF
-      The precision recall stats for model #{args[:model].class.name} on field #{args[:field]}
+      The precision recall stats for model #{args[:model].constantize} on field #{args[:field]}
 
       using query_string #{args[:query_string]}:
 
       precision = #{stats[:precision]}%
       recall = #{stats[:recall]}%
+
+      The precision statistic indicates how many of the total retrieved documents are relevant.
+
+      The recall statistic indicates how many of the total relevant documents have been retrieved.
     EOF
 
-    info.split("\n").each {|line| CipherStash::Protect::Logger.info(line) }
+    logger = Logger.new(STDOUT, level: :info)
+
+    info.split("\n").each {|line| logger.info(line) }
   end
 end

--- a/spec/protect/match_query_statistics_spec.rb
+++ b/spec/protect/match_query_statistics_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe CipherStash::Protect::Query::MatchQueryStatistics do
+  describe "#run" do
+    let(:model) {
+      Class.new(ActiveRecord::Base) do
+        self.table_name = CrudTesting.table_name
+        secure_search :email
+        secure_text_search :email,
+          filter_size: 1024, filter_term_bits: 6,
+          bloom_filter_id: "4f108250-53f8-013b-0bb5-0e015c998817",
+          tokenizer: { kind: :standard },
+          token_filters: [{kind: :downcase}, {kind: :ngram, min_length: 3, max_length: 8}]
+      end
+    }
+
+    it "generates basic precision recall stats" do
+      model.insert_all([
+        { email: "danna@cummings.info" },
+        { email: "dannie@hahn.name" },
+        { email: "marybeth@kertzmann-bailey.org" },
+        { email: "mariann@williamson.org" },
+        { email: "dannika@smith.info"},
+        { email: "marissa@hartmann.com" },
+      ])
+
+      stats = CipherStash::Protect::Query::MatchQueryStatistics.new({model: model, field: :email, query_string: "dann"}).run()
+
+      expect(stats[:precision]).to eq(100)
+      expect(stats[:recall]).to eq(100)
+      expect(stats[:retrieved_records].sort()).to eq(["danna@cummings.info", "dannie@hahn.name", "dannika@smith.info" ])
+    end
+  end
+end


### PR DESCRIPTION
This PR adds in a class that generates the precision and recall stats for a provided model, field and query string.

A rake task has been added that initalizes and runs this class, and logs the stats to the terminal.

<img width="883" alt="Screen Shot 2023-01-04 at 11 25 26 am" src="https://user-images.githubusercontent.com/26052576/210463017-dad1a1d2-5f6b-4522-919b-375f71b1dc58.png">

To test, I created a separate rails app and inserted 1000 records into the db.

Example app here https://github.com/fimac/filter_test_app